### PR TITLE
metal: Implicit CAMetalLayer allocation

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,30 @@
+name: ios
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build - IOS
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-ios
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+        override: true
+
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        use-cross: true
+        command: check
+        args: --target=${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ exclude = [".github/*"]
 ash = "0.31"
 raw-window-handle = "0.3"
 
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+raw-window-metal = "0.1"
+
 [dev-dependencies]
 beryllium = "0.1.2"
 winit = "0.19.4"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ raw-window-handle = "0.3"
 
 - [x] Windows (`VK_KHR_win32_surface`)
 - [x] Unix (`VK_KHR_xlib_surface`/`VK_KHR_xcb_surface`/`VK_KHR_wayland_surface`)
-- [x] MacOS/IOS (`VK_MVK_macos_surface`/`VK_MVK_ios_surface`, `VK_EXT_metal_surface` not exposed yet)
+- [x] MacOS/IOS (`VK_EXT_metal_surface`)
 - [x] Android (`VK_KHR_android_surface`)
 
 ## License


### PR DESCRIPTION
Allocates implicitly a CAMetalLayer in case the provided window handle doesnt have one.
Experimental as not tested - one ugly point is that the CAMetalLayer doesn't get destroyed I think

Looking for feedback
cc https://github.com/norse-rs/ash-window/issues/8