### PR TITLE
Switch from impl to dyn for passing raw window handle trait objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use ash::extensions::mvk;
 pub unsafe fn create_surface<E, I>(
     entry: &E,
     instance: &I,
-    window_handle: &impl HasRawWindowHandle,
+    window_handle: &dyn HasRawWindowHandle,
     allocation_callbacks: Option<&vk::AllocationCallbacks>,
 ) -> VkResult<vk::SurfaceKHR>
 where
@@ -108,7 +108,7 @@ where
 ///
 /// The returned extensions will include all extension dependencies.
 pub fn enumerate_required_extensions(
-    window_handle: &impl HasRawWindowHandle,
+    window_handle: &dyn HasRawWindowHandle,
 ) -> VkResult<Vec<&'static CStr>> {
     let extensions = match window_handle.raw_window_handle() {
         #[cfg(target_os = "windows")]


### PR DESCRIPTION
Should make it a bit easier for interacting with the library due to increased flexibility.
This is mostly due to static dispatching enforces functions interacting with `ash-window` to also use static dispatching which can be annoying (e.g having an `Option<impl HasRawWindowHandle>`).

Using `dyn HasRawWindowHandle` relaxes the constraints a bit due to not having to explicit name the type as sometimes there is none.

Unfortunately, this is still not completely flexible as `RawWindowHandle` doesn't implement `HasRawWindowHandle`, so there is no way to get back the abstraction ladder. Using `&RawWindowHandle` would add the requirement for users to also add `raw-window-handle` dependency just to have access to `HasRawWindowHandle::raw_window_handle` ..