### PR TITLE
Bumping ash version to 0.31.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ash-window"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["msiglreith <m.siglreith@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ categories = ["game-engines", "graphics"]
 exclude = [".github/*"]
 
 [dependencies]
-ash = "0.30"
+ash = "0.31"
 raw-window-handle = "0.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Interoperability between [`ash`](https://github.com/MaikKlein/ash) and [`raw-window-handle`](https://github.com/rust-windowing/raw-window-handle) for surface creation.
 
 ```toml
-ash-window = "0.3"
+ash-window = "0.4"
 ```
 
 ## Usage
@@ -42,7 +42,7 @@ ash_window::create_surface(&entry, &instance, &window, None)?;
 
 ## Versions
 ```toml
-ash = "0.30"
+ash = "0.31"
 raw-window-handle = "0.3"
 ```
 

--- a/examples/beryllium.rs
+++ b/examples/beryllium.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .iter()
             .map(|ext| ext.as_ptr())
             .collect::<Vec<_>>();
-        let app_desc = vk::ApplicationInfo::builder().api_version(ash::vk_make_version!(1, 0, 0));
+        let app_desc = vk::ApplicationInfo::builder().api_version(vk::make_version(1, 0, 0));
         let instance_desc = vk::InstanceCreateInfo::builder()
             .application_info(&app_desc)
             .enabled_extension_names(&instance_extensions);

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .iter()
             .map(|ext| ext.as_ptr())
             .collect::<Vec<_>>();
-        let app_desc = vk::ApplicationInfo::builder().api_version(ash::vk_make_version!(1, 0, 0));
+        let app_desc = vk::ApplicationInfo::builder().api_version(vk::make_version(1, 0, 0));
         let instance_desc = vk::InstanceCreateInfo::builder()
             .application_info(&app_desc)
             .enabled_extension_names(&instance_extensions);


### PR DESCRIPTION
Hi,
Ash 0.31 has been released recently.
I have updated the ash version and also bumped the version of the package because it seems to be the rule here.
I also updated the exemples.